### PR TITLE
chore(#8): Only fire slack alert on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,8 @@ jobs:
           name: "Build Frontend Assets"
           command: npm run prod
 
-      - slack/status
+      - slack/status:
+          fail_only: true
 
 workflows:
   build:


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
Please provide enough information so that others can review your pull request:

Disabling slack alerts when a build passes
