### PR TITLE
feat(#248): Restricting roles from rooms

### DIFF
--- a/app/Http/Controllers/BookingRequestController.php
+++ b/app/Http/Controllers/BookingRequestController.php
@@ -16,13 +16,13 @@ class BookingRequestController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Inertia\Response|\Inertia\ResponseFactory
      */
-    public function index()
+    public function index(Request $request)
     {
         return inertia('Admin/BookingRequests/Index', [
             'booking_requests' => BookingRequest::with('user', 'room')->get(),
-            'rooms' => Room::hideUserRestrictions(auth()->user())->get(),
+            'rooms' => Room::hideUserRestrictions($request->user())->get(),
         ]);
     }
 

--- a/app/Http/Controllers/RestrictionsController.php
+++ b/app/Http/Controllers/RestrictionsController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Room;
+use Illuminate\Http\Request;
+
+class RestrictionsController extends Controller
+{
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Models\Room  $room
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $room)
+    {
+
+        $request->validateWithBag('updateRoomRestriction', [
+            'restrictions' => 'array|present',
+            'restrictions.*' => 'integer',
+        ]);
+        $room = Room::where('id', $room)->firstOrFail();
+
+        $room->restrictions()->sync(collect($request->restrictions));
+
+
+        return redirect(route('rooms.index'))->with('flash', ['updated' => $room]);
+    }
+
+}

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Availability;
+use App\Models\Role;
 use App\Models\Room;
 use Illuminate\Http\Request;
 
@@ -16,7 +17,8 @@ class RoomController extends Controller
     public function index()
     {
         return inertia('Admin/Rooms/Index', [
-            'rooms' => Room::all(),
+            'rooms' => Room::with('restrictions')->get(),
+            'roles' => Role::all()
         ]);
     }
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -63,5 +63,8 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
+        'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
+        'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
     ];
 }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -8,4 +8,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 class Role extends BaseRole
 {
     use HasFactory;
+
+    /**
+     * The rooms this role is restricted from.
+     */
+    public function restrictions()
+    {
+        return $this->belongsToMany(Room::class, 'room_restrictions');
+    }
 }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Spatie\Permission\Models\Role as BaseRole;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -12,7 +13,7 @@ class Role extends BaseRole
     /**
      * The rooms this role is restricted from.
      */
-    public function restrictions()
+    public function restrictions(): BelongsToMany
     {
         return $this->belongsToMany(Room::class, 'room_restrictions');
     }

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -72,13 +72,10 @@ class Room extends Model
     /**
      * Hide rooms restricted by the user's roles
      */
-    public function scopeHideUserRestrictions(Builder $q, User $u = null)
+    public function scopeHideUserRestrictions(Builder $q, User $u)
     {
-        if (!$u) {
-            $u = \Auth::user();
-        }
-
-        $q->whereNotIn('id', $u->roles()->first()->restrictions()->select('id')->get()->pluck('id'));
+        $q->whereNotIn('id', $u->roles()->with('restrictions')->get()
+            ->pluck('restrictions')->flatten()->pluck('id')->unique()->toArray());
     }
 
     /**

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -40,7 +40,7 @@ class Room extends Model
     /**
      * The roles restricted from this room.
      */
-    public function restrictions()
+    public function restrictions(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
     {
         return $this->belongsToMany(Role::class, 'room_restrictions');
     }
@@ -67,6 +67,18 @@ class Room extends Model
     public function scopeAvailable(Builder $q)
     {
         $q->where('status', 'available');
+    }
+
+    /**
+     * Hide rooms restricted by the user's roles
+     */
+    public function scopeHideUserRestrictions(Builder $q, User $u = null)
+    {
+        if (!$u) {
+            $u = \Auth::user();
+        }
+
+        $q->whereNotIn('id', $u->roles()->first()->restrictions()->select('id')->get()->pluck('id'));
     }
 
     /**

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -38,6 +38,14 @@ class Room extends Model
     ];
 
     /**
+     * The roles restricted from this room.
+     */
+    public function restrictions()
+    {
+        return $this->belongsToMany(Role::class, 'room_restrictions');
+    }
+
+    /**
      * Get the booking requests for the room.
      */
     public function bookingRequests()

--- a/config/permission.php
+++ b/config/permission.php
@@ -13,7 +13,7 @@ return [
          * `Spatie\Permission\Contracts\Permission` contract.
          */
 
-        'permission' => Spatie\Permission\Models\Permission::class,
+        'permission' => App\Models\Permission::class,
 
         /*
          * When using the "HasRoles" trait from this package, we need to know which
@@ -24,7 +24,7 @@ return [
          * `Spatie\Permission\Contracts\Role` contract.
          */
 
-        'role' => Spatie\Permission\Models\Role::class,
+        'role' => App\Models\Role::class,
 
     ],
 

--- a/database/migrations/2021_01_17_201148_create_room_restrictions_table.php
+++ b/database/migrations/2021_01_17_201148_create_room_restrictions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRoomRestrictionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('room_restrictions', function (Blueprint $table) {
+            $table->unsignedInteger('role_id');
+            $table->unsignedInteger('room_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('room_restrictions');
+    }
+}

--- a/resources/js/Pages/Admin/Rooms/Index.vue
+++ b/resources/js/Pages/Admin/Rooms/Index.vue
@@ -4,14 +4,14 @@
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
                 Rooms page
             </h2>
-        </template> 
+        </template>
             <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
                 <create-room-form />
             <div v-if="rooms.length > 0">
-                <jet-section-border />
-                <rooms-list :rooms="rooms" />
+            <jet-section-border/>
+            <rooms-list :rooms="rooms" :roles="roles"/>
             </div>
-        </div>  
+        </div>
     </app-layout>
 </template>
 
@@ -30,6 +30,12 @@ export default {
     },
     props: {
         rooms: {
+            type: Array,
+            default: function () {
+                return []
+            },
+        },
+        roles: {
             type: Array,
             default: function () {
                 return []

--- a/resources/js/Pages/Admin/Rooms/RoomsList.vue
+++ b/resources/js/Pages/Admin/Rooms/RoomsList.vue
@@ -16,23 +16,23 @@
                 <template #content>
 
                     <div class="space-y-6">
-                        <div class="grid grid-cols-7">
+                        <div class="grid grid-cols-8">
                             <div class="text-md mx-3">Room Name</div>
                             <div class="text-md mx-3">Room Number</div>
-                            <div class="text-md mx-3">Floor Number</div>
+                            <div class="text-md mx-2">Floor Number</div>
                             <div class="text-md mx-3">Building</div>
                             <div class="text-md mx-3">Status</div>
                         </div>
 
                         <div v-for="room in rooms" :key="room.id" class="grid flex items-center">
-                            <div class="grid grid-cols-7">
+                            <div class="grid grid-cols-8">
                                 <div class="text-md mx-3">
                                     {{ room.name }}
                                 </div>
                                 <div class="text-md mx-3">
                                     {{ room.number }}
                                 </div>
-                                <div class="text-md mx-3">
+                                <div class="text-md mx-2">
                                     {{ room.floor }}
                                 </div>
                                 <div class="text-md mx-3">
@@ -61,7 +61,7 @@
                                 <div class="text-md mx-2">
                                 <button class="cursor-pointer ml-6 text-sm text-blue-800 focus:outline-none"
                                         @click="openEditModal(room)">
-                                    Edit
+                                    Restricted Roles
                                 </button>
                                 </div>
                             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\RestrictionsController;
 use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
@@ -29,7 +30,7 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function() {
     Route::resource('roles',\App\Http\Controllers\RoleController::class)->except(['show', 'edit']);
 
     Route::resource('rooms',\App\Http\Controllers\RoomController::class)->only(['store', 'index', 'update', 'destroy']);
-    Route::resource('rooms',\App\Http\Controllers\RoomController::class)->only(['store', 'index', 'update','destroy']);
+    Route::put('room/restrictions/{id}', RestrictionsController::class.'@update')->name('room.restrictions.update');
 
     Route::resource('settings',SettingsController::class)->only(['index']);
     Route::post('settings/app_logo', SettingsController::class.'@storeAppLogo')->name('app.logo.change');

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,9 +28,9 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function() {
     Route::resource('users', UserController::class)->only(['store', 'index', 'destroy', 'update']);
 
     Route::resource('roles',\App\Http\Controllers\RoleController::class)->except(['show', 'edit']);
-
     Route::resource('rooms',\App\Http\Controllers\RoomController::class)->only(['store', 'index', 'update', 'destroy']);
-    Route::put('room/restrictions/{id}', RestrictionsController::class.'@update')->name('room.restrictions.update');
+    Route::put('room/restrictions/{id}', RestrictionsController::class.'@update')
+        ->name('room.restrictions.update')->middleware('permission:bookings.approve');
 
     Route::resource('settings',SettingsController::class)->only(['index']);
     Route::post('settings/app_logo', SettingsController::class.'@storeAppLogo')->name('app.logo.change');

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,7 +29,7 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function() {
 
     Route::resource('roles',\App\Http\Controllers\RoleController::class)->except(['show', 'edit']);
     Route::resource('rooms',\App\Http\Controllers\RoomController::class)->only(['store', 'index', 'update', 'destroy']);
-    Route::put('room/restrictions/{id}', RestrictionsController::class.'@update')
+    Route::put('room/restrictions/{id}', [RestrictionsController::class, 'update'])
         ->name('room.restrictions.update')->middleware('permission:bookings.approve');
 
     Route::resource('settings',SettingsController::class)->only(['index']);

--- a/tests/Feature/RoomRestrictionsTest.php
+++ b/tests/Feature/RoomRestrictionsTest.php
@@ -7,72 +7,114 @@ use App\Models\Role;
 use App\Models\Room;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class RoomRestrictionsTest extends TestCase
 {
     use RefreshDatabase;
 
+    private $rooms;
+    private $roles;
+    private $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        //Create rooms and roles
+        $rooms = Room::factory()->count(5)->create();
+        $this->rooms = $rooms;
+        $this->roles = Role::factory()->count(5)->create();
+
+        //Give test user permission to update rooms.
+        Permission::create(['name'=>'bookings.approve', 'guard_name'=> 'web']);
+        $this->user = User::factory()->create();
+        $role = $this->roles->first();
+        $role->givePermissionTo('bookings.approve');
+        $this->user->assignRole($role);
+    }
+
     /**
      * Test if the route can create, update and remove restrictions from the system
      *
      * @return void
      */
-    public function test_restrictions_controller()
+    public function test_restrictions_controller_create()
     {
-        //Create rooms and roles
-        $rooms = Room::factory()->count(5)->create();
-        $roles = Role::factory()->count(5)->create();
-
-        //Give test user permission to update rooms.
-        Permission::create(['name'=>'bookings.approve', 'guard_name'=> 'web']);
-        $user = User::factory()->create();
-        $role = $roles->first();
-        $role->givePermissionTo('bookings.approve');
-        $user->assignRole($role);
 
         //Pick our random room and roles.
-        $test_room = $rooms->random();
-        $test_roles = $roles->random(2);
+        $test_room = $this->rooms->random();
+        $test_roles = $this->roles->random(2);
         $test_role1 = $test_roles->first();
         $test_role2 = $test_roles->last();
 
         //Test if we can add a restriction if none are there yet.
         $this->assertDatabaseCount('room_restrictions', 0);
-        $response = $this->actingAs($user)->put('room/restrictions/' . $test_room->id, [
+        $response = $this->actingAs($this->user)->put('room/restrictions/' . $test_room->id, [
             'restrictions' => [$test_role1->id],
         ]);
         $response->assertStatus(302);
         $this->assertDatabaseCount('room_restrictions', 1);
         $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role1->id]);
+    }
+
+    public function test_restrictions_controller_update_1_to_2()
+    {
+        //Pick our random room and roles.
+        $test_room = $this->rooms->random();
+        $test_roles = $this->roles->random(2);
+        $test_role1 = $test_roles->first();
+        $test_role2 = $test_roles->last();
+
+        $test_room->restrictions()->sync(collect($test_role1->id));
 
         //Test if we can add another restriction if one is already there
-        $response = $this->actingAs($user)->put('room/restrictions/' . $test_room->id, [
+        $response = $this->actingAs($this->user)->put('room/restrictions/' . $test_room->id, [
             'restrictions' => [$test_role1->id, $test_role2->id],
         ]);
         $response->assertStatus(302);
         $this->assertDatabaseCount('room_restrictions', 2);
         $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role1->id]);
         $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role2->id]);
+    }
+
+    public function test_restrictions_controller_update_2_to_1()
+    {
+        //Pick our random room and roles.
+        $test_room = $this->rooms->random();
+        $test_roles = $this->roles->random(2);
+        $test_role1 = $test_roles->first();
+        $test_role2 = $test_roles->last();
+
+        $test_room->restrictions()->sync(collect($test_role1->id, $test_role2->id));
 
         //Test if we can remove a restriction if there are multiple attached and not lose any
-        $response = $this->actingAs($user)->put('room/restrictions/' . $test_room->id, [
+        $response = $this->actingAs($this->user)->put('room/restrictions/' . $test_room->id, [
             'restrictions' => [$test_role2->id],
         ]);
         $response->assertStatus(302);
         $this->assertDatabaseCount('room_restrictions', 1);
         $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role2->id]);
+    }
 
+    public function test_restrictions_controller_remove()
+    {
+        //Pick our random room and roles.
+        $test_room = $this->rooms->random();
+        $test_roles = $this->roles->random(2);
+        $test_role1 = $test_roles->first();
+        $test_role2 = $test_roles->last();
+
+        $test_room->restrictions()->sync(collect($test_role1->id, $test_role2->id));
         //Test if we can remove restrictions
-        $response = $this->actingAs($user)->put('room/restrictions/' . $test_room->id, [
+        $response = $this->actingAs($this->user)->put('room/restrictions/' . $test_room->id, [
             'restrictions' => [],
         ]);
         $response->assertStatus(302);
         $this->assertDatabaseCount('room_restrictions', 0);
 
     }
+
     /**
      * Test restrictions rooms scope filter
      *
@@ -80,24 +122,20 @@ class RoomRestrictionsTest extends TestCase
      */
     public function test_restrictions_scope_for_rooms()
     {
-        $this->assertDatabaseCount('room_restrictions', 0);
 
-        Room::factory()->count(5)->create();
-        $role = Role::factory()->create();
-        $user = User::factory()->create();
+        $role = $this->user->roles()->first();
 
         $restricted_room = Room::inRandomOrder()->first();
-        $user->syncRoles($role);
 
         $room_query = Room::all();
-        $result = Room::hideUserRestrictions($user)->get();
+        $result = Room::hideUserRestrictions($this->user)->get();
         //See if all rooms are available before restriction
         $this->assertEquals($result, $room_query);
 
         $restricted_room->restrictions()->sync($role->id);
         $this->assertDatabaseCount('room_restrictions', 1);
 
-        $result = Room::hideUserRestrictions($user)->get();
+        $result = Room::hideUserRestrictions($this->user)->get();
         $this->assertNotEquals($result, $room_query);
 
         $this->assertEquals(4,$result->count());

--- a/tests/Feature/RoomRestrictionsTest.php
+++ b/tests/Feature/RoomRestrictionsTest.php
@@ -22,10 +22,18 @@ class RoomRestrictionsTest extends TestCase
      */
     public function test_restrictions_controller()
     {
+        //Create rooms and roles
         $rooms = Room::factory()->count(5)->create();
         $roles = Role::factory()->count(5)->create();
-        $user = User::factory()->create();
 
+        //Give test user permission to update rooms.
+        Permission::create(['name'=>'bookings.approve', 'guard_name'=> 'web']);
+        $user = User::factory()->create();
+        $role = $roles->first();
+        $role->givePermissionTo('bookings.approve');
+        $user->assignRole($role);
+
+        //Pick our random room and roles.
         $test_room = $rooms->random();
         $test_roles = $roles->random(2);
         $test_role1 = $test_roles->first();
@@ -66,7 +74,7 @@ class RoomRestrictionsTest extends TestCase
 
     }
     /**
-     * Test restirctions rooms scope filter
+     * Test restrictions rooms scope filter
      *
      * @return void
      */

--- a/tests/Feature/RoomRestrictionsTest.php
+++ b/tests/Feature/RoomRestrictionsTest.php
@@ -13,99 +13,106 @@ class RoomRestrictionsTest extends TestCase
 {
     use RefreshDatabase;
 
-    private $rooms;
-    private $roles;
     private $user;
+    private $rooms;
+    private $test_role1;
+    private $test_role2;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         //Create rooms and roles
-        $rooms = Room::factory()->count(5)->create();
-        $this->rooms = $rooms;
-        $this->roles = Role::factory()->count(5)->create();
+        $this->rooms = Room::factory()->count(5)->create();
+        $roles = Role::factory()->count(5)->create();
 
         //Give test user permission to update rooms.
         Permission::create(['name'=>'bookings.approve', 'guard_name'=> 'web']);
         $this->user = User::factory()->create();
-        $role = $this->roles->first();
+        $role = $roles->first();
         $role->givePermissionTo('bookings.approve');
         $this->user->assignRole($role);
+
+        //Pick our random roles for each test.
+        $test_roles = $roles->random(2);
+        $this->test_role1 = $test_roles->first();
+        $this->test_role2 = $test_roles->last();
     }
 
     /**
-     * Test if the route can create, update and remove restrictions from the system
+     * Test if the route can create restrictions from the system
      *
      * @return void
      */
     public function test_restrictions_controller_create()
     {
-
-        //Pick our random room and roles.
         $test_room = $this->rooms->random();
-        $test_roles = $this->roles->random(2);
-        $test_role1 = $test_roles->first();
-        $test_role2 = $test_roles->last();
-
-        //Test if we can add a restriction if none are there yet.
         $this->assertDatabaseCount('room_restrictions', 0);
+
         $response = $this->actingAs($this->user)->put('room/restrictions/' . $test_room->id, [
-            'restrictions' => [$test_role1->id],
+            'restrictions' => [$this->test_role1->id],
         ]);
         $response->assertStatus(302);
         $this->assertDatabaseCount('room_restrictions', 1);
-        $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role1->id]);
+        $this->assertDatabaseHas('room_restrictions',
+            [
+                'room_id' => $test_room->id,
+                'role_id' => $this->test_role1->id
+            ]);
     }
 
+    /**
+     * Test if the route can update number of restrictions from the system
+     *
+     * @return void
+     */
     public function test_restrictions_controller_update_1_to_2()
     {
-        //Pick our random room and roles.
         $test_room = $this->rooms->random();
-        $test_roles = $this->roles->random(2);
-        $test_role1 = $test_roles->first();
-        $test_role2 = $test_roles->last();
-
-        $test_room->restrictions()->sync(collect($test_role1->id));
+        $test_room->restrictions()->sync([$this->test_role1->id]);
+        $this->assertDatabaseCount('room_restrictions', 1);
 
         //Test if we can add another restriction if one is already there
         $response = $this->actingAs($this->user)->put('room/restrictions/' . $test_room->id, [
-            'restrictions' => [$test_role1->id, $test_role2->id],
+            'restrictions' => [$this->test_role1->id, $this->test_role2->id],
         ]);
         $response->assertStatus(302);
         $this->assertDatabaseCount('room_restrictions', 2);
-        $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role1->id]);
-        $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role2->id]);
+        $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $this->test_role1->id]);
+        $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $this->test_role2->id]);
     }
 
+    /**
+     * Test if the route can update number of restrictions, by reducing, from the system
+     *
+     * @return void
+     */
     public function test_restrictions_controller_update_2_to_1()
     {
-        //Pick our random room and roles.
         $test_room = $this->rooms->random();
-        $test_roles = $this->roles->random(2);
-        $test_role1 = $test_roles->first();
-        $test_role2 = $test_roles->last();
-
-        $test_room->restrictions()->sync(collect($test_role1->id, $test_role2->id));
+        $test_room->restrictions()->sync([$this->test_role1->id, $this->test_role2->id]);
+        $this->assertDatabaseCount('room_restrictions', 2);
 
         //Test if we can remove a restriction if there are multiple attached and not lose any
         $response = $this->actingAs($this->user)->put('room/restrictions/' . $test_room->id, [
-            'restrictions' => [$test_role2->id],
+            'restrictions' => [$this->test_role2->id],
         ]);
         $response->assertStatus(302);
         $this->assertDatabaseCount('room_restrictions', 1);
-        $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role2->id]);
+        $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $this->test_role2->id]);
     }
 
+    /**
+     * Test if the route can remove restrictions from the system
+     *
+     * @return void
+     */
     public function test_restrictions_controller_remove()
     {
-        //Pick our random room and roles.
         $test_room = $this->rooms->random();
-        $test_roles = $this->roles->random(2);
-        $test_role1 = $test_roles->first();
-        $test_role2 = $test_roles->last();
+        $test_room->restrictions()->sync([$this->test_role1->id, $this->test_role2->id]);
+        $this->assertDatabaseCount('room_restrictions', 2);
 
-        $test_room->restrictions()->sync(collect($test_role1->id, $test_role2->id));
         //Test if we can remove restrictions
         $response = $this->actingAs($this->user)->put('room/restrictions/' . $test_room->id, [
             'restrictions' => [],

--- a/tests/Feature/RoomRestrictionsTest.php
+++ b/tests/Feature/RoomRestrictionsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\Room;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class RoomRestrictionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test if the route can create, update and remove restrictions from the system
+     *
+     * @return void
+     */
+    public function test_restrictions_controller()
+    {
+        $rooms = Room::factory()->count(5)->create();
+        $roles = Role::factory()->count(5)->create();
+        $user = User::factory()->create();
+
+        $test_room = $rooms->random();
+        $test_roles = $roles->random(2);
+        $test_role1 = $test_roles->first();
+        $test_role2 = $test_roles->last();
+
+        //Test if we can add a restriction if none are there yet.
+        $this->assertDatabaseCount('room_restrictions', 0);
+        $response = $this->actingAs($user)->put('room/restrictions/' . $test_room->id, [
+            'restrictions' => [$test_role1->id],
+        ]);
+        $response->assertStatus(302);
+        $this->assertDatabaseCount('room_restrictions', 1);
+        $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role1->id]);
+
+        //Test if we can add another restriction if one is already there
+        $response = $this->actingAs($user)->put('room/restrictions/' . $test_room->id, [
+            'restrictions' => [$test_role1->id, $test_role2->id],
+        ]);
+        $response->assertStatus(302);
+        $this->assertDatabaseCount('room_restrictions', 2);
+        $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role1->id]);
+        $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role2->id]);
+
+        //Test if we can remove a restriction if there are multiple attached and not lose any
+        $response = $this->actingAs($user)->put('room/restrictions/' . $test_room->id, [
+            'restrictions' => [$test_role2->id],
+        ]);
+        $response->assertStatus(302);
+        $this->assertDatabaseCount('room_restrictions', 1);
+        $this->assertDatabaseHas('room_restrictions', ['room_id' => $test_room->id, 'role_id' => $test_role2->id]);
+
+        //Test if we can remove restrictions
+        $response = $this->actingAs($user)->put('room/restrictions/' . $test_room->id, [
+            'restrictions' => [],
+        ]);
+        $response->assertStatus(302);
+        $this->assertDatabaseCount('room_restrictions', 0);
+
+    }
+    /**
+     * Test restirctions rooms scope filter
+     *
+     * @return void
+     */
+    public function test_restrictions_scope_for_rooms()
+    {
+        $this->assertDatabaseCount('room_restrictions', 0);
+
+        Room::factory()->count(5)->create();
+        $role = Role::factory()->create();
+        $user = User::factory()->create();
+
+        $restricted_room = Room::inRandomOrder()->first();
+        $user->syncRoles($role);
+
+        $room_query = Room::all();
+        $result = Room::hideUserRestrictions($user)->get();
+        //See if all rooms are available before restriction
+        $this->assertEquals($result, $room_query);
+
+        $restricted_room->restrictions()->sync($role->id);
+        $this->assertDatabaseCount('room_restrictions', 1);
+
+        $result = Room::hideUserRestrictions($user)->get();
+        $this->assertNotEquals($result, $room_query);
+
+        $this->assertEquals(4,$result->count());
+        $this->assertNotContains($restricted_room, $result);
+    }
+
+}

--- a/tests/Javascript/Pages/Admin/Rooms/RoomsList.spec.js
+++ b/tests/Javascript/Pages/Admin/Rooms/RoomsList.spec.js
@@ -55,3 +55,45 @@ test('deleteRoom()', () => {
 
     expect(wrapper.vm.$data.roomBeingDeleted).toBe(null)
 })
+
+
+test('openUpdateRestrictionsModal', () => {
+    let room = {
+        restrictions: ["role1", "role2"]
+    }
+    const wrapper = shallowMount(RoomsList, {localVue})
+    wrapper.vm.openEditModal(room)
+    expect(wrapper.vm.$data.roomRestBeingUpdated).toBe(room);
+})
+
+test('updateRoomRestrictions()', () => {
+
+    let mockRoomResBeingUpdated = {
+        id: 10,
+        roles:['role1', 'roles2']
+    }
+
+    InertiaFormMock.put.mockReturnValueOnce({
+        then(callback) {
+            callback({})
+        }
+    })
+
+    const wrapper = shallowMount(RoomsList, {
+        localVue,
+        data() {
+            return {
+                roomRestBeingUpdated: mockRoomResBeingUpdated
+            }
+        }
+    })
+
+    wrapper.vm.updateRestrictions()
+
+    expect(InertiaFormMock.put).toBeCalledWith('/room/restrictions/'  + mockRoomResBeingUpdated.id, {
+        preserveScroll: true,
+        preserveState: true,
+    })
+
+    expect(wrapper.vm.$data.roomRestBeingUpdated).toBe(null)
+})

--- a/tests/Javascript/Pages/Admin/Rooms/RoomsList.spec.js
+++ b/tests/Javascript/Pages/Admin/Rooms/RoomsList.spec.js
@@ -97,3 +97,37 @@ test('updateRoomRestrictions()', () => {
 
     expect(wrapper.vm.$data.roomRestBeingUpdated).toBe(null)
 })
+
+test('updateRoomRestrictionsFail()', () => {
+
+    let mockRoomResBeingUpdated = {
+        id: 10,
+        roles:['role1', 'roles2']
+    }
+
+    InertiaFormMock.put.mockReturnValueOnce({
+        then(callback) {
+            callback({})
+        }
+    })
+
+    InertiaFormMock.successful = false;
+
+    const wrapper = shallowMount(RoomsList, {
+        localVue,
+        data() {
+            return {
+                roomRestBeingUpdated: mockRoomResBeingUpdated
+            }
+        }
+    })
+
+    wrapper.vm.updateRestrictions()
+
+    expect(InertiaFormMock.put).toBeCalledWith('/room/restrictions/'  + mockRoomResBeingUpdated.id, {
+        preserveScroll: true,
+        preserveState: true,
+    })
+
+    expect(wrapper.vm.$data.roomRestBeingUpdated).toBe(mockRoomResBeingUpdated)
+})


### PR DESCRIPTION

This MR is for adding the feature of limiting access of certain roles from specific rooms. When merged, users who are not able to book certain rooms won't have them appear in their search results or if they manage to get a link to the page, submitting the form will block them form making the booking request. 
<!-- You can skip this if you're making a tiny change, like fixing a typo. -->

### Test plan (required)
Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
<!-- Make sure tests pass in CI. -->
Feature test showing a scope and making sure it hides rooms user is not allowed to book. 
Feature test showing that the api allowing to change restrictions for rooms works
UI test to see if you are able to change the restrictions for a room. 
### Closing issues
List all issues this PR resolves.
- closes #248

### Pre-Merge checklist 
Complete these items before requesting reviews
- [ ] Static Analysis Rules Validated
- [x] All commits follow naming conventions 

### Sub-tasks Checklist
- [x] UI Implementation
- [x] UI Test
- [ ] Backend Implementation
- [ ] Backend Tests
- [ ] Integration Tests
- [ ] System Tests
- [ ] Documentation
