### PR TITLE
fix(#322): use font-awesome classes for i tag as permitted by sonar

### DIFF
--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -53,25 +53,25 @@
                         </div>
                         <div class="flex-1 py-3">
                             <a href="https://www.facebook.com">
-                                <i class="fa"></i>
+                                <i class="fab fa-facebook pr-2"></i>
                                 Facebook
                             </a>
                         </div>
                         <div class="flex-1 py-3">
                             <a href="https://www.instagram.com">
-                                <i class="fa"></i>
+                                <i class="fab fa-instagram pr-2"></i>
                                 Instagram
                             </a>
                         </div>
                         <div class="flex-1 py-3">
                             <a href="https://www.twitter.com">
-                                <i class=""></i>
+                                <i class="fab fa-twitter pr-2"></i>
                                 Twitter
                             </a>
                         </div>
                         <div class="flex-1 py-3">
                             <a href="https://www.youtube.com">
-                                <i class=""></i>
+                                <i class="fab fa-youtube pr-2"></i>
                                 YouTube
                             </a>
                         </div>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -12,6 +12,9 @@
         <link rel="preconnect" href="https://fonts.gstatic.com">
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300&display=swap" rel="stylesheet">
 
+        <!-- Font awesome -->
+        <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.2/css/all.css" integrity="sha384-vSIIfh2YWi9wW0r9iZe7RJPrKwp6bG+s9QZMoITbCckVJqGCCRhc+ccxNcdpHuYu" crossorigin="anonymous">
+
         <!-- Styles -->
         <link rel="stylesheet" href="{{ mix('css/app.css') }}">
         <link rel="stylesheet" href="{{ asset('css/global.css') }}">


### PR DESCRIPTION
Fix Sonarqube warnings about usage of empty <i> tags. Solution: use font-awesome classes for icons which is permitted by sonar.
Using this: https://fontawesome.com/account/cdn

### Closing issues
- closes #322 

### Pre-Merge checklist
- [x] Static Analysis Rules Validated
- [x] All commits follow naming conventions

### Sub-tasks Checklist
- [x] UI Implementation