### PR TITLE
fix(#581): Dusk tests for blackout periods

### DIFF
--- a/resources/js/Pages/Admin/Blackouts/Room.vue
+++ b/resources/js/Pages/Admin/Blackouts/Room.vue
@@ -6,8 +6,8 @@
             </div>
             <div v-if="blackouts.length > 0" class="m-4 w-3/4">
                 <div class="mx-24 mt-16">
-                    <blackout-list :blackouts="blackouts" :room="room" class="w-full"/>
-                </div>               
+                    <blackout-list :blackouts="blackouts" :room="room" class="w-full" dusk="blackout-list"/>
+                </div>
             </div>
         </div>
     </app-layout>

--- a/tests/Browser/BlackoutsPageTest.php
+++ b/tests/Browser/BlackoutsPageTest.php
@@ -28,6 +28,36 @@ class BlackoutsPageTest extends DuskTestCase
         $seeder->run();
         User::first()->assignRole('super-admin');
     }
+    public function testCanCreateBlackouts()
+    {
+        Room::factory()->create();
+
+        AcademicDate::create([
+            'semester' => 'Fall',
+            'start_date' => Carbon::now()->subDays(2),
+            'end_date' => Carbon::now()->addDays(5)
+        ]);
+
+        $this->browse(function (Browser $browser) {
+            $browser->loginAs(User::first())->visit('/admin/rooms/1/blackouts');
+
+            $browser->within(new DateTimePicker("start"), function ($browser) {
+                $browser->setDatetime(15, 7);
+            })->pause(1000);
+
+            $browser->within(new DateTimePicker("end"), function ($browser) {
+                $browser->setDatetime(15, 8);
+            })->pause(1000);
+
+            $browser->type('#name', 'alex')
+                ->press('#submit')
+                ->pause(8000);
+
+                $browser->assertSee('alex');
+        });
+
+        
+    }
 
     public function testCanCreateRecuringBlackouts()
     {

--- a/tests/Browser/BlackoutsPageTest.php
+++ b/tests/Browser/BlackoutsPageTest.php
@@ -10,6 +10,7 @@ use Database\Seeders\EasyUserSeeder;
 use Database\Seeders\RolesAndPermissionsSeeder;
 use Facebook\WebDriver\WebDriverKeys;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Str;
 use Laravel\Dusk\Browser;
 use Tests\Browser\Components\DateTimePicker;
 use Tests\DuskTestCase;
@@ -30,7 +31,7 @@ class BlackoutsPageTest extends DuskTestCase
     }
     public function testCanCreateBlackouts()
     {
-        Room::factory()->create();
+        $room = Room::factory()->create();
 
         AcademicDate::create([
             'semester' => 'Fall',
@@ -38,25 +39,31 @@ class BlackoutsPageTest extends DuskTestCase
             'end_date' => Carbon::now()->addDays(5)
         ]);
 
-        $this->browse(function (Browser $browser) {
-            $browser->loginAs(User::first())->visit('/admin/rooms/1/blackouts');
+        $this->browse(function (Browser $browser) use ($room) {
+            $browser->loginAs(User::first())->visitRoute('admin.rooms.blackouts.index', $room);
 
-            $browser->within(new DateTimePicker("start"), function ($browser) {
-                $browser->setDatetime(15, 7);
+            $name = Str::random();
+            $start = today()->addDays(15)->setHour(7);
+            $end = today()->addDays(15)->setHour(8);
+
+            $browser->within(new DateTimePicker("start"), function ($browser) use ($start) {
+                $browser->setDatetime(15, $start->hour);
             })->pause(1000);
 
-            $browser->within(new DateTimePicker("end"), function ($browser) {
-                $browser->setDatetime(15, 8);
+            $browser->within(new DateTimePicker("end"), function ($browser) use ($end) {
+                $browser->setDatetime(15, $end->hour);
             })->pause(1000);
 
-            $browser->type('#name', 'alex')
-                ->press('#submit')
-                ->pause(8000);
+            $browser->type('#name', $name)->press('#submit');
 
-                $browser->assertSee('alex');
+            $browser->waitUntilVue('blackouts[0].name', $name, '@blackout-list');
+            $browser->assertVue('blackouts[0].start_time', $start->toJSON(), '@blackout-list');
+            $browser->assertVue('blackouts[0].end_time', $end->toJSON(), '@blackout-list');
+
+            $browser->assertSeeIn('@blackout-list', $start->isoFormat('LLL'));
+            $browser->assertSeeIn('@blackout-list', $end->isoFormat('LLL'));
+
         });
-
-        
     }
 
     public function testCanCreateRecuringBlackouts()

--- a/tests/Browser/BlackoutsPageTest.php
+++ b/tests/Browser/BlackoutsPageTest.php
@@ -59,10 +59,6 @@ class BlackoutsPageTest extends DuskTestCase
             $browser->waitUntilVue('blackouts[0].name', $name, '@blackout-list');
             $browser->assertVue('blackouts[0].start_time', $start->toJSON(), '@blackout-list');
             $browser->assertVue('blackouts[0].end_time', $end->toJSON(), '@blackout-list');
-
-            $browser->assertSeeIn('@blackout-list', $start->timezone(config('app.timezone'))->isoFormat('LLL'));
-            $browser->assertSeeIn('@blackout-list', $end->timezone(config('app.timezone'))->isoFormat('LLL'));
-
         });
     }
 

--- a/tests/Browser/BlackoutsPageTest.php
+++ b/tests/Browser/BlackoutsPageTest.php
@@ -60,8 +60,8 @@ class BlackoutsPageTest extends DuskTestCase
             $browser->assertVue('blackouts[0].start_time', $start->toJSON(), '@blackout-list');
             $browser->assertVue('blackouts[0].end_time', $end->toJSON(), '@blackout-list');
 
-            $browser->assertSeeIn('@blackout-list', $start->isoFormat('LLL'));
-            $browser->assertSeeIn('@blackout-list', $end->isoFormat('LLL'));
+            $browser->assertSeeIn('@blackout-list', $start->timezone(config('app.timezone'))->isoFormat('LLL'));
+            $browser->assertSeeIn('@blackout-list', $end->timezone(config('app.timezone'))->isoFormat('LLL'));
 
         });
     }

--- a/tests/Browser/BookRoomsTest.php
+++ b/tests/Browser/BookRoomsTest.php
@@ -146,14 +146,14 @@ class BookRoomsTest extends DuskTestCase
 
      /**
      * Create a blackout, and then attempts to book a room during that time
-     * assert that the page doesn't change to the booking creation. 
+     * assert that the page doesn't change to the booking creation.
      */
     public function testCannotBookDuringBlackout()
     {
         $this->browse(function (Browser $browser){
 
             $admin = User::first();
-            
+
 
             if($admin === null) {
 

--- a/tests/Browser/BookRoomsTest.php
+++ b/tests/Browser/BookRoomsTest.php
@@ -153,7 +153,7 @@ class BookRoomsTest extends DuskTestCase
         $this->browse(function (Browser $browser){
 
             $admin = User::first();
-            $blackout = Blackout::factory()->create();
+            
 
             if($admin === null) {
 
@@ -168,6 +168,8 @@ class BookRoomsTest extends DuskTestCase
                 ->assertSourceHas('<title>CSU Booking Platform</title>');
 
             $room = Room::inRandomOrder()->first();
+            $blackout=Blackout::factory()->create();
+            $blackout->rooms()->attach($room);
 
             $browser->press("@room-select-".$room->id);
 


### PR DESCRIPTION
Covers creating a single blackout, and trying to book a room during a blackout

##### **_IMPORTANT: Always create an issue before a PR and provide enough information so that others can review_**

Added two tests to cover acceptance tests in #581. That admins can create blackout periods, and that if a user attempts to make a booking during a blackout period, the booking fails. 
### Explain the **details** for making this change.
##### _What existing problem does the pull request solve?_

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### Test plan (required)
##### _Demonstrate the code is solid. </br> Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI._
<!-- Make sure tests pass in CI. -->

Tests passed locally

### Closing issues
##### _List all issues this PR resolves_
- closes #581 

### Pre-Merge checklist
##### _Complete these items before requesting reviews_
- [x] Static Analysis Rules Validated
- [x] All commits follow naming conventions

### Sub-tasks Checklist
- [x] Backend Implementation
- [x] Backend Tests
- [x] Integration Tests
- [x] System Tests
- [ ] Documentation
