### PR TITLE
fix(#665): Adjust max height of advanced filters modal

### DIFF
--- a/resources/js/Components/Tables/RoomTable.vue
+++ b/resources/js/Components/Tables/RoomTable.vue
@@ -194,7 +194,7 @@
           </template>
 
           <template #content>
-            <div class="overflow-y-auto h-96">
+            <div class="overflow-y-auto">
               <div class="flex flex-row">
                   <div class="flex flex-col flex-1 py-2 px-3">
                       <div><h2>Capacity Standing</h2></div>
@@ -363,7 +363,7 @@
                 />
               </div>
               </div>
-              <div class="flex flex-wrap grid grid-cols-2 gap-4">
+              <div class="flex flex-wrap grid grid-cols-2 gap-4 max-h-72">
                 <div v-for="(dates, index) in jsonFilters.recurrences" :key="index">
                   <div class="m-6">
                     <jet-label for="start_time" value="Start Time" />


### PR DESCRIPTION
##### **_IMPORTANT: Always create an issue before a PR and provide enough information so that others can review_**

<!-- You can skip this if you're making a tiny change, like fixing a typo. -->

### Explain the **details** for making this change.
##### _What existing problem does the pull request solve?_

The Advanced Filter modal was not increasing in size to match screen space. If dates were added, the modal became scrollable but stayed the same size

### Test plan (required)
##### _Demonstrate the code is solid. </br> Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI._
Now the height of the overall modal isn't limited, but the height of the section containing the dates is. If rooms are added, the modal extends but not so far that the buttons below are removed. 
![FilterModal0](https://user-images.githubusercontent.com/31771444/114290329-ed0a4f80-9a4c-11eb-8577-165b68604a5f.PNG)

![FilterModal](https://user-images.githubusercontent.com/31771444/114290286-a7e61d80-9a4c-11eb-8784-2f273e360e42.PNG)


### Closing issues
##### _List all issues this PR resolves_
- closes #665 

### Pre-Merge checklist
##### _Complete these items before requesting reviews_
- [x] Static Analysis Rules Validated
- [x] All commits follow naming conventions

### Sub-tasks Checklist
- [x] UI Implementation
- [x] UI Test
